### PR TITLE
Remove blobs/ directory from git

### DIFF
--- a/cf-usb-release/blobs/consul/.gitignore
+++ b/cf-usb-release/blobs/consul/.gitignore
@@ -1,2 +1,0 @@
-/consul-template_0.9.0_linux_amd64.tar.gz
-/consul_0.5.2_linux_amd64.zip


### PR DESCRIPTION
The files in it will be deleted by bosh 2.0, leaving the git repo in a dirty state.