### PR TITLE
Switch back to insecure CC endpoint

### DIFF
--- a/cf-usb-release/jobs/cf-usb/spec
+++ b/cf-usb-release/jobs/cf-usb/spec
@@ -54,7 +54,7 @@ properties:
     description: Password to login to mysql for config
   cf-usb.mysql_address:
     description: The mysql server address and port
-  cf.api_url:
+  cf.insecure_api_url:
     description: The cloudcontroller's api endpoint
   cf-usb.skip_tls_validation:
     description: Skip TLS validation

--- a/cf-usb-release/jobs/cf-usb/templates/usb_mysql_config.sql.erb
+++ b/cf-usb-release/jobs/cf-usb/templates/usb_mysql_config.sql.erb
@@ -12,7 +12,7 @@ INSERT INTO usb.Config (`KEY`,VALUE,COMPONENT) VALUES
 ;
 INSERT INTO usb.Config (`KEY`,VALUE,COMPONENT) VALUES
 ('BROKER_NAME','<%= p("cf-usb.management.broker_name") %>','MANAGEMENT_API')
-,('API','<%= p("cf.api_url") %>','CLOUD_CONTROLLER')
+,('API','<%= p("cf.insecure_api_url") %>','CLOUD_CONTROLLER')
 ,('SKIP_TLS_VALIDATION','<%= p("cf-usb.skip_tls_validation") %>','CLOUD_CONTROLLER')
 ,('USERNAME','<%= p("cf-usb.broker.username") %>','BROKER_CREDENTIALS')
 ,('PASSWORD','<%= p("cf-usb.broker.password") %>','BROKER_CREDENTIALS')

--- a/cf-usb-release/jobs/cf-usb/templates/usb_mysql_create_db.sql.erb
+++ b/cf-usb-release/jobs/cf-usb/templates/usb_mysql_create_db.sql.erb
@@ -2,7 +2,7 @@
 -- Mon Nov 14 14:44:06 2016
 -- Model: New Model    Version: 1.0
 -- MySQL Workbench Forward Engineering
--- <%= p("cf.api_url") %>
+-- <%= p("cf.insecure_api_url") %>
 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';


### PR DESCRIPTION
The TLS one requires client certs, and even if we provide those it doesn't expose the correct endpoints.