### PR TITLE
Update CC service broker configs on startup

### DIFF
--- a/lib/mgmt/configure_usb_mgmt.go
+++ b/lib/mgmt/configure_usb_mgmt.go
@@ -263,6 +263,7 @@ func ConfigureAPI(api *operations.UsbMgmtAPI, auth authentication.Authentication
 			log.Error("get-service-broker-failed", err)
 			return &operations.RegisterDriverEndpointInternalServerError{Payload: err.Error()}
 		}
+		log.Info("create-or-update-service-broker", lager.Data{"guid": guid})
 
 		if guid == "" {
 			err = ccServiceBroker.Create(brokerName, config.BrokerAPI.ExternalURL, config.BrokerAPI.Credentials.Username, config.BrokerAPI.Credentials.Password)


### PR DESCRIPTION
On startup, we will now update all service broker configuration for service brokers which match our broker URL and user name.  This is needed so that if the broker secrets were regenerated restarting the USB role would cause the brokers to automatically update and pick up the new passwords.